### PR TITLE
Update API when first starting agent

### DIFF
--- a/agent360/agent360.py
+++ b/agent360/agent360.py
@@ -399,7 +399,12 @@ class Agent:
         max_cached_collections = self.config.get('agent', 'max_cached_collections')
         cached_collections = []
         collection = []
+        initial_data = True
         while True:
+            if initial_data:
+                max_age = 10
+            else:
+                max_age = self.config.getint('agent', 'max_data_age')
             loop_ts = time.time()
             if self.shutdown:
                 logging.info('%s:shutdown', threading.currentThread())
@@ -425,6 +430,7 @@ class Agent:
                     send = True
                     clean = True
                 if send:
+                    initial_data = False
                     headers = {
                         "Content-type": "application/json",
                         "Authorization": "ApiKey %s:%s" % (user, server),

--- a/agent360/agent360.py
+++ b/agent360/agent360.py
@@ -404,7 +404,7 @@ class Agent:
             if initial_data:
                 max_age = 10
             else:
-                max_age = self.config.getint('agent', 'max_data_age')
+                max_age = self.config.getint('agent', 'max_data_span')
             loop_ts = time.time()
             if self.shutdown:
                 logging.info('%s:shutdown', threading.currentThread())


### PR DESCRIPTION
When the agent first starts report back to the api in 10 seconds instead of 60. This way the user more quickly should be able to see the data in the dashboard and Plesk Monitoring.