### PR TITLE
Adding monitor for fail2ban

### DIFF
--- a/agent360/plugins/fail2ban.py
+++ b/agent360/plugins/fail2ban.py
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import os
+import subprocess
+import plugins
+import json
+
+class Plugin(plugins.BasePlugin):
+    __name__ = 'fail2ban'
+
+    def run(self, config):
+        '''
+        Monitor currently banned IP's, specify the fail2ban jail you want to monitor in /etc/agent360.ini
+        
+        Example:
+        [fail2ban]
+        enabled = yes
+        jail = sshd
+        
+        Nota bene: agent360 requires sudo permission to access fail2ban-client 
+        '''
+
+        data = {}
+        jail = config.get('fail2ban', 'jail').split(',')
+
+        for nom in jail:
+            data[nom] = {'count': os.popen('/bin/fail2ban-client status '+ nom +' | egrep -i "Currently banned:.*"  | egrep -o "[0-9.]+"').read().rstrip()}
+
+        return data
+
+
+if __name__ == '__main__':
+    Plugin().execute()

--- a/agent360/plugins/fail2ban.py
+++ b/agent360/plugins/fail2ban.py
@@ -24,7 +24,7 @@ class Plugin(plugins.BasePlugin):
         jail = config.get('fail2ban', 'jail').split(',')
 
         for nom in jail:
-            data[nom] = {'count': os.popen('/bin/fail2ban-client status '+ nom +' | egrep -i "Currently banned:.*"  | egrep -o "[0-9.]+"').read().rstrip()}
+            data[nom] = {'count': os.popen('sudo /bin/fail2ban-client status '+ nom +' | egrep -i "Currently banned:.*"  | egrep -o "[0-9.]+"').read().rstrip()}
 
         return data
 

--- a/agent360/plugins/fail2ban.py
+++ b/agent360/plugins/fail2ban.py
@@ -28,6 +28,5 @@ class Plugin(plugins.BasePlugin):
 
         return data
 
-
 if __name__ == '__main__':
     Plugin().execute()


### PR DESCRIPTION
This plugin allow to monitor and flow of currently banned ip's by fail2ban.

![Screenshot 2023-04-24 at 21-27-23 Server 642d8a6a24df5b423223cd15 Metric Fail2ban -360 Monitoring](https://user-images.githubusercontent.com/107129718/234096396-1faa4005-2b68-463c-bb63-832cee7310a1.png)
