### PR TITLE
[hotfix] not working in new windows versions, adding try:

### DIFF
--- a/agent360/plugins/ping.py
+++ b/agent360/plugins/ping.py
@@ -77,6 +77,12 @@ def collect_ping(hostname):
                 response = -1
         except CalledProcessError:
             pass
+        if response == -1:
+            try:
+                rxresponse = re.findall(br"Average = (\d+)", out)
+                response = rxresponse[0].decode()
+            except Exception:
+                pass
     else:
         #response = float(system_command("ping -W -c 1 " + hostname))
         response = -1

--- a/agent360/plugins/ping.py
+++ b/agent360/plugins/ping.py
@@ -79,7 +79,7 @@ def collect_ping(hostname):
             pass
         if response == -1:
             try:
-                rxresponse = re.findall(br"Average = (\d+)", out)
+                rxresponse = re.findall(br" + .+ = [0-9]{1,9}ms, .+ = [0-9]{1,9}ms, .+ = (\d+){1,9}ms", out)
                 response = rxresponse[0].decode()
             except Exception:
                 pass


### PR DESCRIPTION
Script is returning -1 on the newest win versions, therefore adding a new "try:" to solve this.

before:
```
C:\Program Files\Agent360\src\agent360.py:23: DeprecationWarning: the imp module is deprecated in favour of importlib and slated for removal in Python 3.12; see the module's documentation for alternative uses
  import imp
ping:
[
    {
        "avgping": -1,
        "host": "hel.360monitoring.io"
    },
    {
        "avgping": -1,
        "host": "nbg.360monitoring.io"
    },
    {
        "avgping": -1,
        "host": "fks.360monitoring.io"
    }
]
```
after:
```
C:\Program Files\Agent360\src\agent360.py:23: DeprecationWarning: the imp module is deprecated in favour of importlib and slated for removal in Python 3.12; see the module's documentation for alternative uses
  import imp
ping:
[
    {
        "avgping": "78",
        "host": "hel.360monitoring.io"
    },
    {
        "avgping": "61",
        "host": "nbg.360monitoring.io"
    },
    {
        "avgping": "60",
        "host": "fks.360monitoring.io"
    }
]
```